### PR TITLE
Add Cabal-Hunter (Solana multi-threat rug scanner, MCP/agent-native)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [BscCheck](https://www.bscheck.eu)
 - [quickintel](https://app.quickintel.io/scanner)
 - [HAPI Labs](https://terminal.hapilabs.one/guest-address-check/)
+- [Cabal-Hunter](https://api.cabal-hunter.com/) (Solana; fuses cabal-cluster tracing + same-block bundles + coordinated dumps + serial-rug deployer history + honeypot into one agent-callable Exit-Liquidity verdict — MCP + REST)
 
 [CertiK Skynet](https://skynet.certik.com/) stands out by covering an exceptionally broad range of information (for a limited set of tokens).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - [BscCheck](https://www.bscheck.eu)
 - [quickintel](https://app.quickintel.io/scanner)
 - [HAPI Labs](https://terminal.hapilabs.one/guest-address-check/)
-- [Cabal-Hunter](https://api.cabal-hunter.com/) (Solana; fuses cabal-cluster tracing + same-block bundles + coordinated dumps + serial-rug deployer history + honeypot into one agent-callable Exit-Liquidity verdict — MCP + REST)
+- [Cabal-Hunter](https://api.cabal-hunter.com/)
 
 [CertiK Skynet](https://skynet.certik.com/) stands out by covering an exceptionally broad range of information (for a limited set of tokens).
 


### PR DESCRIPTION
Adds **Cabal-Hunter** to Token Rug Checking → Multi-threat.

It's a Solana-native scanner built for AI trading agents: given a token mint it fuses funding-cluster/cabal tracing, same-block Jito bundle detection, coordinated-dump detection, serial-rug deployer history and Solana honeypot checks into a single Exit-Liquidity Risk verdict — every flag linked to its on-chain evidence — in one MCP or REST call. 250 free scans/month, no signup.

Live: https://api.cabal-hunter.com  ·  MCP: https://api.cabal-hunter.com/mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)